### PR TITLE
make build.sh more generic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,15 +2,7 @@
 
 set -e
 
-# make sure that we are under project folder
-mkdir -p build
-pushd build
-
-cmake ..
-make -j `grep -c ^processor /proc/cpuinfo`
-
-popd
-
+# get system type
 unamestr="$(uname)"
 if [[ "$unamestr" == "Linux" ]]; then
     LIBRARY_NAME_SUFFIX=so
@@ -19,6 +11,19 @@ elif [[ "$unamestr" == "Darwin" ]]; then
 else
     LIBRARY_NAME_SUFFIX=dll
 fi
+
+# make sure that we are under project folder
+mkdir -p build
+pushd build
+
+cmake ..
+if [[ "$unamestr" == "Darwin" ]]; then
+    make -j `sysctl -n machdep.cpu.thread_count`
+else
+    make -j `grep -c ^processor /proc/cpuinfo`
+fi
+
+popd
 
 # install to build/lib
 mkdir -p build/lib/lib64

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ mkdir -p build
 pushd build
 
 cmake ..
-make -j 8
+make -j `grep -c ^processor /proc/cpuinfo`
 
 popd
 


### PR DESCRIPTION
1) make `build.sh` executable(chmod +x build.sh), so we can type `./build.sh` to run it.
2) `make -j 8` does not adapt to all CPUs, in other word, it is not generic.