### PR TITLE
Downgrade the version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.10)
 project(dsa)
 
 include(ExternalProject)


### PR DESCRIPTION
  In recent Ubuntu 18.04, the default version of cmake is 3.10.2, and it
can build this project successfully.